### PR TITLE
Add RKE Annotation for external and internal ip

### DIFF
--- a/internal/k8s/main.go
+++ b/internal/k8s/main.go
@@ -28,6 +28,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const (
+	internalAddressAnnotation = "rke.io/external-ip"
+	externalAddressAnnotation = "rke.io/internal-ip"
+)
+
 // ParseNameNS parses a string searching a namespace and name
 func ParseNameNS(input string) (string, string, error) {
 	nsName := strings.Split(input, "/")
@@ -59,6 +64,14 @@ func GetNodeIPOrName(kubeClient clientset.Interface, name string, useInternalIP 
 				if address.Address != "" {
 					return address.Address
 				}
+			}
+		}
+		if node.Annotations != nil {
+			if annotatedIP := node.Annotations[externalAddressAnnotation]; annotatedIP != "" {
+				return annotatedIP
+			}
+			if annotatedIP := node.Annotations[internalAddressAnnotation]; annotatedIP != "" {
+				return annotatedIP
 			}
 		}
 	}


### PR DESCRIPTION
Related issue https://github.com/rancher/rke/pull/444 and
https://github.com/rancher/rancher/issues/12169

Since RKE can not set external ip for the node, we need to select from
node annotation.
So when we choose to report external ip, we will follow this order:
1. node.status.addresses.externalIp
2. node.metadata.annotations["rke.io/external-ip"]
3. node.metadata.annotations["rke.io/internal-ip"]
