### PR TITLE
Add v0.10.2 ARM64 image build support

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file zip && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 
 RUN wget -O - https://storage.googleapis.com/golang/go1.9.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
@@ -16,6 +16,7 @@ RUN wget -O - https://storage.googleapis.com/golang/go1.9.3.linux-${!GOLANG_ARCH
 
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
     DOCKER_URL=DOCKER_URL_${ARCH}
 
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker

--- a/scripts/build
+++ b/scripts/build
@@ -8,7 +8,7 @@ cd $(dirname $0)/..
 declare -A OS_ARCH_ARG
 
 OS_PLATFORM_ARG=(linux)
-OS_ARCH_ARG[linux]="amd64"
+OS_ARCH_ARG[linux]="amd64 arm64"
 PKG="k8s.io/ingress-nginx"
 
 if [ -n "$CROSS" ]; then

--- a/scripts/package
+++ b/scripts/package
@@ -20,7 +20,7 @@ package (){
         GOARCH=arm
         DUMB_ARCH=armhf
     fi
-    if [ "$2"= "arm64" ]; then
+    if [ "$2" = "arm64" ]; then
         QEMUARCH=aarch64
     fi
     if [ "$2" = "ppc64le"]; then
@@ -44,6 +44,7 @@ package (){
         docker run --rm --privileged multiarch/qemu-user-static:register --reset
         curl -sSL "https://github.com/multiarch/qemu-user-static/releases/download/${QEMUVERSION}/x86_64_qemu-${QEMUARCH}-static.tar.gz" | tar -xz -C tmp
         sed -i "s/CROSS_BUILD_//g" $dockerfilename
+        sed -i "s|QEMUARCH|$QEMUARCH|g" $dockerfilename
     fi
 
     echo "building image $IMAGE_NAME:$TAG"


### PR DESCRIPTION
**Included**  
Add support for building ingress-nginx v0.10.2 image for ARM64.

**Why using 0.10.2**
According to https://github.com/kubernetes/ingress-nginx/issues/2802, ingress-nginx v0.16.2 can not run on ARM64 platform now.

**Related issue**  
https://github.com/rancher/rancher/issues/16461

**Build Environment**  
Since ingress-nginx used golang cross-compiling, AMD64 and ARM64 images are both built in AMD64 environment.