### PR TITLE
Easy way to rebase new ingress controller release

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,25 @@
+FROM ubuntu:16.04
+# FROM arm=armhf/ubuntu:16.04
+ARG DAPPER_HOST_ARCH
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
+RUN apt-get update && \
+    apt-get install -y gcc ca-certificates git wget curl vim less file zip make && \
+    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+RUN wget -O - https://storage.googleapis.com/golang/go1.9.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get golang.org/x/lint/golint && go get -u github.com/jteeuwen/go-bindata/...
+ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
+    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+    DOCKER_URL=DOCKER_URL_${ARCH}
+RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
+ENV DAPPER_SOURCE /go/src/k8s.io/ingress-nginx/
+ENV DAPPER_OUTPUT ./bin ./dist
+ENV DAPPER_DOCKER_SOCKET true
+ENV DAPPER_ENV CROSS TAG
+ENV DAPPER_RUN_ARGS="--net host"
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["./scripts/entry"]
+CMD ["ci"]

--- a/Makefile_rancher
+++ b/Makefile_rancher
@@ -1,0 +1,23 @@
+TARGETS := $(shell ls scripts)
+
+.dapper:
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
+
+$(TARGETS): .dapper
+	./.dapper $@
+
+trash: .dapper
+	./.dapper -m bind trash
+
+trash-keep: .dapper
+	./.dapper -m bind trash -k
+
+deps: trash
+
+.DEFAULT_GOAL := ci
+
+.PHONY: $(TARGETS)

--- a/internal/ingress/annotations/rewrite/main.go
+++ b/internal/ingress/annotations/rewrite/main.go
@@ -39,7 +39,7 @@ type Config struct {
 	// AppRoot defines the Application Root that the Controller must redirect if it's in '/' context
 	AppRoot string `json:"appRoot"`
 	// UseRegex indicates whether or not the locations use regex paths
-	UseRegex bool `json:useRegex`
+	UseRegex bool `json:"useRegex"`
 }
 
 // Equal tests for equality between two Redirect types

--- a/patchs/patch
+++ b/patchs/patch
@@ -1,0 +1,90 @@
+diff --git a/internal/k8s/main.go b/internal/k8s/main.go
+index d10f3e5db..10fed6035 100644
+--- a/internal/k8s/main.go
++++ b/internal/k8s/main.go
+@@ -28,6 +28,11 @@ import (
+ 	"k8s.io/client-go/tools/cache"
+ )
+ 
++const (
++	internalAddressAnnotation = "rke.cattle.io/internal-ip"
++	externalAddressAnnotation = "rke.cattle.io/external-ip"
++)
++
+ // ParseNameNS parses a string searching a namespace and name
+ func ParseNameNS(input string) (string, string, error) {
+ 	nsName := strings.Split(input, "/")
+@@ -56,6 +61,15 @@ func GetNodeIPOrName(kubeClient clientset.Interface, name string, useInternalIP
+ 		}
+ 	}
+ 
++	if node.Annotations != nil {
++		if annotatedIP := node.Annotations[externalAddressAnnotation]; annotatedIP != "" {
++			return annotatedIP
++		}
++		if annotatedIP := node.Annotations[internalAddressAnnotation]; annotatedIP != "" {
++			return annotatedIP
++		}
++	}
++
+ 	for _, address := range node.Status.Addresses {
+ 		if address.Type == apiv1.NodeExternalIP {
+ 			if address.Address != "" {
+@@ -92,11 +106,28 @@ func GetPodDetails(kubeClient clientset.Interface) (*PodInfo, error) {
+ 		return nil, fmt.Errorf("unable to get POD information")
+ 	}
+ 
++	var labels map[string]string
++	owners := pod.GetOwnerReferences()
++	if len(owners) == 0 {
++		labels = pod.GetLabels()
++	} else {
++		labels = make(map[string]string)
++		for _, owner := range owners {
++			switch owner.Kind {
++			case "DaemonSet":
++				ds, _ := kubeClient.ExtensionsV1beta1().DaemonSets(podNs).Get(owner.Name, metav1.GetOptions{})
++				for k := range ds.Spec.Template.ObjectMeta.Labels {
++					labels[k] = ds.Spec.Template.ObjectMeta.Labels[k]
++				}
++			}
++		}
++	}
++
+ 	return &PodInfo{
+ 		Name:      podName,
+ 		Namespace: podNs,
+ 		NodeIP:    GetNodeIPOrName(kubeClient, pod.Spec.NodeName, true),
+-		Labels:    pod.GetLabels(),
++		Labels:    labels,
+ 	}, nil
+ }
+ 
+diff --git a/test/e2e/e2e_test.go b/test/e2e/e2e_test.go
+index 8de277bc5..a022bc34d 100644
+--- a/test/e2e/e2e_test.go
++++ b/test/e2e/e2e_test.go
+@@ -19,9 +19,6 @@ package e2e
+ import (
+ 	"testing"
+ 
+-	"github.com/golang/glog"
+-	"k8s.io/client-go/tools/clientcmd"
+-
+ 	"k8s.io/ingress-nginx/test/e2e/framework"
+ )
+ 
+@@ -29,9 +26,12 @@ func init() {
+ 	framework.RegisterParseFlags()
+ 
+ 	if "" == framework.TestContext.KubeConfig {
+-		glog.Fatalf("environment variable %v must be set", clientcmd.RecommendedConfigPathEnvVar)
++		//glog.Fatalf("environment variable %v must be set", clientcmd.RecommendedConfigPathEnvVar)
+ 	}
+ }
+ func TestE2E(t *testing.T) {
++	if "" == framework.TestContext.KubeConfig {
++		t.Skip("test is skiped because kubeconfig is missing")
++	}
+ 	RunE2ETests(t)
+ }

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+declare -a OS_ARCH_ARG
+
+# only support amd64 for now
+OS_ARCH_ARG=(amd64)
+PKG="k8s.io/ingress-nginx"
+
+rm -rf bin/*
+mkdir -p bin
+for ARCH in ${OS_ARCH_ARG}; do
+  ARCH=$ARCH source ./scripts/envs
+  echo "Building bin/${ARCH}/nginx-ingress-controller"
+  OUTPUT_BIN="bin/$ARCH/nginx-ingress-controller"
+  export CGO_ENABLED=0 
+  go build \
+      -a -installsuffix cgo \
+      -ldflags="-s -w \
+      -X ${PKG}/version.RELEASE=${TAG} \
+      -X ${PKG}/version.COMMIT=${COMMIT} \
+      -X ${PKG}/version.REPO=${REPO_INFO}" \
+      -o ${OUTPUT_BIN} ${PKG}/cmd/nginx
+done

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./build
+./test
+./validate
+./package

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p bin dist
+if [ -e ./scripts/$1 ]; then
+    ./scripts/"$@"
+else
+    exec "$@"
+fi
+
+chown -R $DAPPER_UID:$DAPPER_GID .

--- a/scripts/envs
+++ b/scripts/envs
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [ "$ARCH" = "arm" ]; then
+	QEMUARCH=arm
+	GOARCH=arm
+	DUMB_ARCH=armhf
+fi
+if [ "$ARCH" = "arm64" ]; then
+	QEMUARCH=aarch64
+fi
+if [ "$ARCH" = "ppc64le" ]; then
+	QEMUARCH=ppc64le
+	GOARCH=ppc64le
+	DUMB_ARCH=ppc64el
+fi
+if [ "$ARCH" = "s390x" ]; then
+	QEMUARCH=s390x
+fi

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+REPO=${REPO:-rancher}
+# SCRIPTPATH="$(cd "$(dirname "$0")"; pwd -P)"
+# QEMUVERSION=v2.9.1-1
+# IMAGE=$REPO/nginx-ingress-controller
+
+source $(dirname $0)/version
+cd $(dirname $0)/..
+# go-bindata -o internal/file/bindata.go -prefix="rootfs" -pkg=file -ignore=Dockerfile -ignore=".DS_Store" rootfs/...
+# mkdir -p package
+# package (){
+#     pushd package
+#     local dockerfilename QEMUARCH GOARCH DUMB_ARCH BASEIMAGE IMAGE_NAME
+#     BASEIMAGE=${BASEIMAGE:-"quay.io/kubernetes-ingress-controller/nginx-$2:0.32"}
+#     IMAGE_NAME=$IMAGE-$2
+#     if [ "$2" = "arm" ]; then
+#         QEMUARCH=arm
+#         GOARCH=arm
+#         DUMB_ARCH=armhf
+#     fi
+#     if [ "$2"= "arm64" ]; then
+#         QEMUARCH=aarch64
+#     fi
+#     if [ "$2" = "ppc64le"]; then
+#         QEMUARCH=ppc64le
+#         GOARCH=ppc64le
+#         DUMB_ARCH=ppc64el
+#     fi
+#     if [ "$2" = "s390x" ]; then
+#         QEMUARCH=s390x
+#     fi
+
+#     dockerfilename="tmp/Dockerfile"
+#     mkdir tmp
+#     cp ../bin/$1/$2/nginx-ingress-controller ./tmp
+#     cp -r ../rootfs/* ./tmp/
+#     sed -i "s|BASEIMAGE|$BASEIMAGE|g" $dockerfilename
+
+#     if [ "$2" == "amd64" ]; then
+#         sed -i "/CROSS_BUILD_/d" $dockerfilename
+#     else 
+#         docker run --rm --privileged multiarch/qemu-user-static:register --reset
+#         curl -sSL "https://github.com/multiarch/qemu-user-static/releases/download/${QEMUVERSION}/x86_64_qemu-${QEMUARCH}-static.tar.gz" | tar -xz -C tmp
+#         sed -i "s/CROSS_BUILD_//g" $dockerfilename
+#     fi
+
+#     echo "building image $IMAGE_NAME:$TAG"
+#     docker build -t $IMAGE_NAME:$TAG tmp
+
+#     if [ "$2" == "amd64" ]; then
+#         docker tag $IMAGE_NAME:$TAG $IMAGE:$TAG
+#     fi
+#     rm -rf tmp
+#     popd
+# }
+
+# source $SCRIPTPATH/version
+# cd $SCRIPTPATH/..
+
+for arch in $(ls bin); do
+  REGISTRY=${REPO} ARCH=${arch} TAG=${TAG} make -f Makefile_k8s container
+done

--- a/scripts/rancher-prepare
+++ b/scripts/rancher-prepare
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+source $(dirname $0)/version
+
+resetTag(){
+  local tag
+  tag=${1}
+  if [ -n "$tag" ]; then
+    git tag -d "$tag"
+    git tag "$tag"
+  fi
+}
+
+exitFunc()
+{
+  git reset --hard $GIT_COMMIT && resetTag "${GIT_TAG}"
+}
+
+trap exitFunc EXIT
+
+cd $(dirname $0)/..
+mv Makefile Makefile_k8s
+mv Makefile_rancher Makefile
+
+cat >>.gitignore<< EOF
+
+# rancher ci
+.dapper
+/dist/
+EOF
+
+git apply patchs/patch && git add -A . && git commit -m "Rancher ci commit" && resetTag "${GIT_TAG}"
+
+$@

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec $(dirname $0)/ci

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running tests
+
+FIND_COMMAND="find"
+if [ "$(go env GOHOSTOS)" = "darwin" ]; then
+  FIND_COMMAND="find ."
+fi
+
+PACKAGES="$($FIND_COMMAND -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin|e2e|images|examples)' | sed -e 's!^!./!' -e 's!$!/...!')"
+
+go test -cover ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running validation
+
+FIND_COMMAND="find"
+if [ "$(go env GOHOSTOS)" = "darwin" ]; then
+  FIND_COMMAND="find ."
+fi
+
+PACKAGES="$($FIND_COMMAND -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin|test|images)' | sed -e 's!^!./!' -e 's!$!/...!')"
+
+echo Running: go vet
+go vet ${PACKAGES}
+# not doing golint check because it is not required in community
+# echo Running: golint
+# for i in ${PACKAGES}; do
+#    if [ -n "$(golint $i | grep -v 'should have comment.*or be unexported' | tee /dev/stderr)" ]; then
+#        failed=true
+#    fi
+# done
+test -z "$failed"
+echo Running: go fmt
+test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"

--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    DIRTY="-dirty"
+fi
+
+GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
+GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
+REPO_INFO=$(git config --get remote.origin.url)
+
+if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    VERSION=$GIT_TAG
+else
+    VERSION="${GIT_COMMIT}${DIRTY}"
+fi
+
+if [ -z "$ARCH" ]; then
+    ARCH=amd64
+fi
+
+TAG=${TAG:-$VERSION}
+
+PKG="k8s.io/ingress-nginx"


### PR DESCRIPTION
We can use this commit to rebase every ingress-nginx release after 0.20.0.
After rebased, we can easily do `./scripts/rancher-prepare make` to do CI in Rancher style. The script will keep the commit and tag and we will create a new commit for Rancher changes while building.