### PR TITLE
Add multiarch CICD support for drone-1.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,9 +1,102 @@
----
-pipeline:
-  build:
-    privileged: true
-    image: rancher/dapper:1.11.2
+kind: pipeline
+name: amd64
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: build
+    image: rancher/dapper:v0.4.1
+    environment:
+      GIT_IN_DAPPER: true
     volumes:
-    - /var/run/docker.sock:/var/run/docker.sock
+      - name: docker
+        path: /var/run/docker.sock
     commands:
-    - ./scripts/rancher-prepare dapper ci
+      - apk add --no-cache git
+      - apk add --no-cache bash
+      - ./scripts/rancher-prepare dapper ci
+  - name: publish-amd64
+    image: docker
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    environment:
+      USERNAME:
+        from_secret: dockerhub_username
+      PASSWORD:
+        from_secret: dockerhub_password
+    commands:
+      - "docker login -u $USERNAME -p $PASSWORD"
+      - "docker push rancher/nginx-ingress-controller-amd64:${DRONE_TAG}"
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+---
+kind: pipeline
+name: arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: build
+    image: rancher/dapper:v0.4.1
+    environment:
+      GIT_IN_DAPPER: true
+    volumes:
+      - name: docker
+        path: /var/run/docker.sock
+    commands:
+      - apk add --no-cache git
+      - apk add --no-cache bash
+      - ./scripts/rancher-prepare dapper ci
+  - name: publish-arm64
+    image: docker
+    volumes:
+        - name: docker
+          path: /var/run/docker.sock
+    environment:
+      USERNAME:
+        from_secret: dockerhub_username
+      PASSWORD:
+        from_secret: dockerhub_password
+    commands:
+      - "docker login -u $USERNAME -p $PASSWORD"
+      - "docker push rancher/nginx-ingress-controller-arm64:${DRONE_TAG}"
+    when:
+      event:
+        - tag
+volumes:
+  - name: docker
+    host:
+      path: /var/run/docker.sock
+---
+kind: pipeline
+name: manifest
+
+steps:
+  - name: push-manifest
+    image: plugins/manifest:1.0.2
+    settings:
+      username:
+        from_secret: dockerhub_username
+      password:
+        from_secret: dockerhub_password
+      target: "rancher/nginx-ingress-controller:${DRONE_TAG}"
+      template: "rancher/nginx-ingress-controller-ARCH:${DRONE_TAG}"
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    when:
+      event:
+        - tag
+depends_on:
+- amd64
+- arm64

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -5,12 +5,13 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 RUN apt-get update && \
     apt-get install -y gcc ca-certificates git wget curl vim less file zip make && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 RUN wget -O - https://dl.google.com/go/go1.11.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get golang.org/x/lint/golint && go get -u github.com/jteeuwen/go-bindata/...
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
     DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+    DOCKER_URL_arm64=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm64 \
     DOCKER_URL=DOCKER_URL_${ARCH}
 RUN wget -O - ${!DOCKER_URL} > /usr/bin/docker && chmod +x /usr/bin/docker
 ENV DAPPER_SOURCE /go/src/k8s.io/ingress-nginx/
@@ -20,6 +21,7 @@ ENV DAPPER_ENV CROSS TAG
 ENV DAPPER_RUN_ARGS="--net host"
 ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 ENV HOME ${DAPPER_SOURCE}
+ENV GIT_IN_DAPPER true
 WORKDIR ${DAPPER_SOURCE}
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/scripts/build
+++ b/scripts/build
@@ -5,24 +5,20 @@ source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
-declare -a OS_ARCH_ARG
-
-# only support amd64 for now
-OS_ARCH_ARG=(amd64)
 PKG="k8s.io/ingress-nginx"
 
 rm -rf bin/*
 mkdir -p bin
-for ARCH in ${OS_ARCH_ARG}; do
-  ARCH=$ARCH source ./scripts/envs
-  echo "Building bin/${ARCH}/nginx-ingress-controller"
-  OUTPUT_BIN="bin/$ARCH/nginx-ingress-controller"
-  export CGO_ENABLED=0 
-  go build \
-      -a -installsuffix cgo \
-      -ldflags="-s -w \
-      -X ${PKG}/version.RELEASE=${TAG} \
-      -X ${PKG}/version.COMMIT=${COMMIT} \
-      -X ${PKG}/version.REPO=${REPO_INFO}" \
-      -o ${OUTPUT_BIN} ${PKG}/cmd/nginx
-done
+
+ARCH=$ARCH source ./scripts/envs
+echo "Building bin/${ARCH}/nginx-ingress-controller"
+OUTPUT_BIN="bin/$ARCH/nginx-ingress-controller"
+export CGO_ENABLED=0 
+GOARCH=$ARCH
+go build \
+    -a -installsuffix cgo \
+    -ldflags="-s -w \
+    -X ${PKG}/version.RELEASE=${TAG} \
+    -X ${PKG}/version.COMMIT=${COMMIT} \
+    -X ${PKG}/version.REPO=${REPO_INFO}" \
+    -o ${OUTPUT_BIN} ${PKG}/cmd/nginx

--- a/scripts/version
+++ b/scripts/version
@@ -1,8 +1,16 @@
 #!/bin/bash
 
+if [ "$GIT_IN_DAPPER" = true ]; then
+    git config --global user.email "rancher-ci@rancher.com"
+    git config --global user.name "rancher-ci"
+fi
+
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"
 fi
+
+# fetch tag information
+git fetch
 
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
 GIT_TAG=$(git tag -l --contains HEAD | head -n 1)


### PR DESCRIPTION
This PR includes the following changes.
- Modified the build scripts for using drone1.0 to build both amd64 and arm64 docker images.
- Added the drone1.0 config file for multiarch CICD.
- Use `docker manifest` to publish multiarch docker images.

The config file `.drone-multiarch.yml` and the rancher  `dockerhub_username ` and `dockerhub_password ` need to be set to the repo in drone-1.0 server.

Issue
https://github.com/rancher/rancher/issues/16461
https://github.com/rancher/rancher/issues/16518
