### PR TITLE
CI Publish Fix - Option 3

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -16,7 +16,7 @@ GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
 GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
 REPO_INFO=$(git config --get remote.origin.url)
 
-if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+if [[ -n "$GIT_TAG" ]]; then
     VERSION=$GIT_TAG
 else
     VERSION="${GIT_COMMIT}${DIRTY}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:
This is needed since the validation stage modifies `go.sum` and if this change is not made, the image will be tagged with `<SHORT_SHA>-dirty`