### PR TITLE
v0.35.0 & refactor build process to work with upstream changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,32 @@
+---
+kind: pipeline
+name: ci
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: rancher/dapper:v0.5.3
+  commands:
+  - dapper ci
+  environment:
+    GIT_IN_DAPPER: true
+    DOCKER_PASS:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+    instance:
+    - drone-publish.rancher.io
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ images/fastcgi-helloserver/rootfs/fastcgi-helloserver
 cmd/plugin/release/ingress-nginx.yaml
 cmd/plugin/release/*.tar.gz
 cmd/plugin/release/LICENSE
+
+# rancher ci
+.dapper
+/dist/

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,44 @@
+FROM docker:19.03.8
+ARG DAPPER_HOST_ARCH
+ENV ARCH=${DAPPER_HOST_ARCH}
+RUN mkdir -p /.docker/cli-plugins
+RUN apk update && apk upgrade && apk add bash && ln -sf /bin/bash /bin/sh # use bash for subsequent variable expansion
+ENV DOCKER_BUILDX_URL_arm=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-arm-v7 \
+    DOCKER_BUILDX_URL_arm64=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-arm64 \
+    DOCKER_BUILDX_URL_amd64=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 \
+    DOCKER_BUILDX_URL=DOCKER_BUILDX_URL_${ARCH}
+RUN wget -O - ${!DOCKER_BUILDX_URL} > /.docker/cli-plugins/docker-buildx && chmod +x /.docker/cli-plugins/docker-buildx
+
+FROM ubuntu:18.04
+ARG DAPPER_HOST_ARCH
+ARG DOCKER_USER
+ARG DOCKER_PASS
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} \
+    ARCH=${DAPPER_HOST_ARCH} \
+    DOCKER_USER=${DOCKER_USER} \
+    DOCKER_PASS=${DOCKER_PASS}
+RUN apt-get update && \
+    apt-get install -y gcc ca-certificates git wget curl vim less file zip make && \
+    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+RUN wget -O - https://dl.google.com/go/go1.14.1.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get golang.org/x/lint/golint && go get -u github.com/jteeuwen/go-bindata/...
+COPY --from=0 /usr/local/bin/docker /usr/bin/docker
+RUN mkdir -p /.docker/cli-plugins
+COPY --from=0 /.docker/cli-plugins/docker-buildx /.docker/cli-plugins/docker-buildx
+ENV DOCKER_CLI_EXPERIMENTAL=enabled \
+    DOCKER_CONFIG=/.docker
+RUN docker buildx install
+ENV DAPPER_SOURCE /go/src/k8s.io/ingress-nginx/
+ENV DAPPER_OUTPUT ./bin ./dist
+ENV DAPPER_DOCKER_SOCKET true
+ENV DAPPER_ENV CROSS TAG
+ENV DAPPER_RUN_ARGS="--net host"
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+ENV GIT_IN_DAPPER true
+RUN mkdir -p /etc/nginx/geoip
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["./scripts/entry"]
+CMD ["ci"]

--- a/Makefile
+++ b/Makefile
@@ -218,4 +218,4 @@ release: ensure-buildx clean
 		--build-arg VERSION="$(TAG)" \
 		--build-arg COMMIT_SHA="$(COMMIT_SHA)" \
 		--build-arg BUILD_ID="$(BUILD_ID)" \
-		-t $(REGISTRY)/controller:$(TAG) rootfs
+		-t $(REGISTRY)/nginx-ingress-controller:$(TAG) rootfs

--- a/Makefile_rancher
+++ b/Makefile_rancher
@@ -1,0 +1,23 @@
+TARGETS := $(shell ls scripts)
+
+.dapper:
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
+
+$(TARGETS): .dapper
+	./.dapper $@
+
+trash: .dapper
+	./.dapper -m bind trash
+
+trash-keep: .dapper
+	./.dapper -m bind trash -k
+
+deps: trash
+
+.DEFAULT_GOAL := ci
+
+.PHONY: $(TARGETS)

--- a/internal/k8s/main.go
+++ b/internal/k8s/main.go
@@ -32,6 +32,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const (
+	internalAddressAnnotation = "rke.cattle.io/internal-ip"
+	externalAddressAnnotation = "rke.cattle.io/external-ip"
+)
+
 // ParseNameNS parses a string searching a namespace and name
 func ParseNameNS(input string) (string, string, error) {
 	nsName := strings.Split(input, "/")
@@ -62,6 +67,15 @@ func GetNodeIPOrName(kubeClient clientset.Interface, name string, useInternalIP 
 
 	if useInternalIP {
 		return defaultOrInternalIP
+	}
+
+	if node.Annotations != nil {
+		if annotatedIP := node.Annotations[externalAddressAnnotation]; annotatedIP != "" {
+			return annotatedIP
+		}
+		if annotatedIP := node.Annotations[internalAddressAnnotation]; annotatedIP != "" {
+			return annotatedIP
+		}
 	}
 
 	for _, address := range node.Status.Addresses {

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+PKG="k8s.io/ingress-nginx"
+
+rm -rf bin/*
+mkdir -p bin
+
+declare -a arches=("arm64" "amd64")
+for arch in "${arches[@]}"
+do
+   ARCH=$arch DOCKER_IN_DOCKER_ENABLED=true USER=0 make build
+done

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./validate
+./build
+./test
+./package

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p bin dist
+if [ -e ./scripts/$1 ]; then
+    ./scripts/"$@"
+else
+    exec "$@"
+fi
+
+chown -R $DAPPER_UID:$DAPPER_GID .

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+REPO=${REPO:-rancher}
+
+source $(dirname $0)/version
+cd $(dirname $0)/..
+
+# manifest push happens as part of make release, so login is required inside the dapper container
+echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
+
+REGISTRY=${REPO} PLATFORMS="arm64 amd64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec $(dirname $0)/ci

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running tests
+
+FIND_COMMAND="find"
+if [ "$(go env GOHOSTOS)" = "darwin" ]; then
+  FIND_COMMAND="find ."
+fi
+
+PACKAGES="$($FIND_COMMAND -name '*.go' | xargs -I{} dirname {} | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin|docs|test|controller/store|images|examples|hack)')"
+
+go test -v -p 1 -tags "cgo" -cover ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running validation
+
+PACKAGES="$(go list ./... | grep -v /vendor/)"
+
+echo Running: go vet
+go vet -mod=readonly ${PACKAGES}
+
+echo Running: go fmt
+test -z "$(go fmt -mod=readonly ${PACKAGES} | tee /dev/stderr)"

--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ "$GIT_IN_DAPPER" = true ]; then
+    git config --global user.email "rancher-ci@rancher.com"
+    git config --global user.name "rancher-ci"
+fi
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    DIRTY="-dirty"
+fi
+
+# fetch tag information
+git fetch
+
+GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
+GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
+REPO_INFO=$(git config --get remote.origin.url)
+
+if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    VERSION=$GIT_TAG
+else
+    VERSION="${GIT_COMMIT}${DIRTY}"
+fi
+
+if [ -z "$ARCH" ]; then
+    ARCH=amd64
+fi
+
+TAG=${TAG:-$VERSION}
+
+PKG="k8s.io/ingress-nginx"


### PR DESCRIPTION
These changes will allow our build system to create the 0.35.0 image when a tag is pushed.

NOTE: This was not a simple port of the changes for the previous controller version we released (0.32.0) due to the upstream refactoring their build / release process. Specifically, they are leveraging some additional features of docker buildx that allow for building and pushing of a multiarch manifest in a single command. Previously the image builds per arch were handled separately and there was a separate pipeline stage in our `.drone.yml` to create and push the manifest. Due to this functionality being integrated into the upstream's `release` Makefile rule, we only need one pipeline stage in our drone configuration now.