### PR TITLE
check isPodReady to confirm ingress controller is running

### DIFF
--- a/internal/ingress/status/status.go
+++ b/internal/ingress/status/status.go
@@ -195,6 +195,20 @@ func (s *statusSync) runningAddresses() ([]string, error) {
 			continue
 		}
 
+		// only Ready pods are valid
+		isPodReady := false
+		for _, cond := range pod.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status == "True" {
+				isPodReady = true
+				break
+			}
+		}
+
+		if !isPodReady {
+			klog.Infof("runningAddresses: pod [%s] on [%s] is not ready", pod.Name, pod.Spec.NodeName)
+			continue
+		}
+
 		name := k8s.GetNodeIPOrName(s.Client, pod.Spec.NodeName, s.UseNodeInternalIP)
 		if !sliceutils.StringInSlice(name, addrs) {
 			addrs = append(addrs, name)


### PR DESCRIPTION
Problem:
When node's powered off, the pod stays in running state so the node's Ip address doesn't get removed. As far as I can see, this is k8s upstream problem (`https://github.com/kubernetes/kubernetes/issues/55713`) and the state changes to terminating only after the pod is deleted manually. 

Workaround:
Manually delete the pod so the state changes. 

Code Solution:
Rely on pod.Status.Conditions.Ready since it is updated accurately.

Notes:
The default state of pod readiness before the initial delay is Failure. So with this logic, there might be a slight delay initially for the ingress LB addresses to show up. (If a Container does not provide a readiness probe, the default state is Success.)

Issue:
https://github.com/rancher/rancher/issues/13862 