### PR TITLE
update test for checking pod ready condition

### DIFF
--- a/internal/ingress/status/status_test.go
+++ b/internal/ingress/status/status_test.go
@@ -72,6 +72,12 @@ func buildSimpleClientSet() *testclient.Clientset {
 				},
 				Status: apiv1.PodStatus{
 					Phase: apiv1.PodRunning,
+					Conditions: []apiv1.PodCondition{
+						{
+							Type:   apiv1.PodReady,
+							Status: apiv1.ConditionTrue,
+						},
+					},
 				},
 			},
 			{


### PR DESCRIPTION
With https://github.com/rancher/ingress-nginx/pull/35, we now check for pod's ready condition so that ingress updates ip addresses correctly when node's powered off. 

Updating pods' conditions to reflect that so that `TestStatusActions` doesn't fail, https://drone-publish.rancher.io/rancher/ingress-nginx/23/1/2 

rancher/rancher#13862