### PR TITLE
Add apk-tools first

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -34,6 +34,7 @@ LABEL build_id="${BUILD_ID}"
 WORKDIR  /etc/nginx
 
 RUN apk update \
+  && apk add apk-tools \
   && apk upgrade \
   && apk add --no-cache \
     diffutils \


### PR DESCRIPTION
**Problem:**
Apk-tools needs to finish installing  before busybox can succesfully install on arm. Prior, apk-tools would start installing first but frequently busybox would start installing before apk-tools installation finished in drone. Specifically, the trigger script for busybox would fail while building arm image in drone.

**Solution:**
Now, apk-tools package is installed first.