### PR TITLE
Revert "Add apk-tools first"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,6 @@ release: ensure-buildx clean
 	echo "Building and pushing ingress-nginx image..."
 	@docker buildx build \
 		--no-cache \
-		--push \
 		--progress plain \
 		--platform $(subst $(SPACE),$(COMMA),$(PLATFORMS)) \
 		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -34,7 +34,6 @@ LABEL build_id="${BUILD_ID}"
 WORKDIR  /etc/nginx
 
 RUN apk update \
-  && apk add apk-tools \
   && apk upgrade \
   && apk add --no-cache \
     diffutils \

--- a/scripts/build
+++ b/scripts/build
@@ -15,3 +15,5 @@ for arch in "${arches[@]}"
 do
    ARCH=$arch DOCKER_IN_DOCKER_ENABLED=true USER=0 make build
 done
+
+PLATFORMS="arm64 amd64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release

--- a/scripts/build
+++ b/scripts/build
@@ -17,3 +17,4 @@ do
 done
 
 PLATFORMS="arm64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release
+PLATFORMS="amd64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release

--- a/scripts/build
+++ b/scripts/build
@@ -16,4 +16,4 @@ do
    ARCH=$arch DOCKER_IN_DOCKER_ENABLED=true USER=0 make build
 done
 
-PLATFORMS="arm64 amd64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release
+PLATFORMS="arm64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release

--- a/scripts/build
+++ b/scripts/build
@@ -17,4 +17,3 @@ do
 done
 
 PLATFORMS="arm64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release
-PLATFORMS="amd64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release


### PR DESCRIPTION
Seems like it's no longer required for `0.46.x`