### PR TITLE
Fix flaky arm64 build failure

### DIFF
--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -46,7 +46,9 @@ fi
 # We only need to do this setup on linux hosts
 if [ "$(uname)" == 'Linux' ]; then
   # NOTE: this is pinned to a digest for a reason!
-  docker run --rm --privileged multiarch/qemu-user-static@sha256:28ebe2e48220ae8fd5d04bb2c847293b24d7fbfad84f0b970246e0a4efd48ad6 --reset -p yes
+  # https://github.com/docker/buildx/issues/542#issuecomment-778835576
+  docker run --rm --privileged tonistiigi/binfmt --uninstall qemu-aarch64 && docker run --rm --privileged tonistiigi/binfmt --install arm64 
+  docker run --rm --privileged tonistiigi/binfmt
 fi
 
 # Ensure we use a builder that can leverage it (the default on linux will not)

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -34,7 +34,6 @@ LABEL build_id="${BUILD_ID}"
 WORKDIR  /etc/nginx
 
 RUN apk update \
-  && apk add apk-tools \
   && apk upgrade \
   && apk add --no-cache \
     diffutils \


### PR DESCRIPTION
**Problem:** 
arm64 builds would fail randomly with errors like - 
`error: failed to solve: rpc error: code = Unknown desc = executor failed running [/dev/.buildkit_qemu_emulator /bin/sh -c apk add --no-cache busybox=1.32.1-r6]: exit code: 1`

Doesn't reproduce locally, and doesn't reproduce on all amazon linux instances. Seemed very specific to drone like ec2 instance and failed randomly there as well. 

**Notes:** 
- [778570203]( https://github.com/docker/buildx/issues/542#issuecomment-778570203), `That it is trying to use /dev/.buildkit_qemu_emulator is a sign that the emulator is not installed properly to be used by the containers`. 

- Ran [778790938](https://github.com/docker/buildx/issues/542#issuecomment-778790938) a couple of times, and confirmed that it gives a different set of supported emulators. 

**Fix:** 
https://github.com/docker/buildx/issues/542#issuecomment-778835576, huge thanks to @superseb for finding this out! 🌮 

