### PR TITLE
Add nginx-0.48.x-fix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
   arch: amd64
 
 steps:
-- name: build
+- name: ci
   image: rancher/dapper:v0.5.3
   commands:
   - dapper ci
@@ -23,9 +23,58 @@ steps:
   when:
     event:
     - tag
-    - push
-    instance:
+  instance:
     - drone-publish.rancher.io
+
+- name: validate
+  image: rancher/dapper:v0.5.3
+  commands:
+  - dapper validate
+  environment:
+    GIT_IN_DAPPER: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - push
+    - pull_request
+    instance:
+    - drone-pr.rancher.io
+
+
+- name: build
+  image: rancher/dapper:v0.5.3
+  commands:
+  - dapper build
+  environment:
+    GIT_IN_DAPPER: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - push
+    - pull_request
+    instance:
+    - drone-pr.rancher.io
+
+
+- name: test
+  image: rancher/dapper:v0.5.3
+  commands:
+  - dapper test
+  environment:
+    GIT_IN_DAPPER: true
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - push
+    - pull_request
+    instance:
+    - drone-pr.rancher.io
 
 volumes:
 - name: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -23,6 +23,7 @@ steps:
   when:
     event:
     - tag
+    - push
     instance:
     - drone-publish.rancher.io
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,32 @@
+---
+kind: pipeline
+name: ci
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  image: rancher/dapper:v0.5.3
+  commands:
+  - dapper ci
+  environment:
+    GIT_IN_DAPPER: true
+    DOCKER_PASS:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+    instance:
+    - drone-publish.rancher.io
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ images/fastcgi-helloserver/rootfs/fastcgi-helloserver
 cmd/plugin/release/ingress-nginx.yaml
 cmd/plugin/release/*.tar.gz
 cmd/plugin/release/LICENSE
+
+# rancher ci
+.dapper
+/dist/

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,11 +1,11 @@
-FROM docker:19.03.8
+FROM docker:19.03.9
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}
 RUN mkdir -p /.docker/cli-plugins
 RUN apk update && apk upgrade && apk add bash && ln -sf /bin/bash /bin/sh # use bash for subsequent variable expansion
-ENV DOCKER_BUILDX_URL_arm=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-arm-v7 \
-    DOCKER_BUILDX_URL_arm64=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-arm64 \
-    DOCKER_BUILDX_URL_amd64=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 \
+ENV DOCKER_BUILDX_URL_arm=https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-arm-v7 \
+    DOCKER_BUILDX_URL_arm64=https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-arm64 \
+    DOCKER_BUILDX_URL_amd64=https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 \
     DOCKER_BUILDX_URL=DOCKER_BUILDX_URL_${ARCH}
 RUN wget -O - ${!DOCKER_BUILDX_URL} > /.docker/cli-plugins/docker-buildx && chmod +x /.docker/cli-plugins/docker-buildx
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,0 +1,44 @@
+FROM docker:19.03.8
+ARG DAPPER_HOST_ARCH
+ENV ARCH=${DAPPER_HOST_ARCH}
+RUN mkdir -p /.docker/cli-plugins
+RUN apk update && apk upgrade && apk add bash && ln -sf /bin/bash /bin/sh # use bash for subsequent variable expansion
+ENV DOCKER_BUILDX_URL_arm=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-arm-v7 \
+    DOCKER_BUILDX_URL_arm64=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-arm64 \
+    DOCKER_BUILDX_URL_amd64=https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64 \
+    DOCKER_BUILDX_URL=DOCKER_BUILDX_URL_${ARCH}
+RUN wget -O - ${!DOCKER_BUILDX_URL} > /.docker/cli-plugins/docker-buildx && chmod +x /.docker/cli-plugins/docker-buildx
+
+FROM ubuntu:18.04
+ARG DAPPER_HOST_ARCH
+ARG DOCKER_USER
+ARG DOCKER_PASS
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} \
+    ARCH=${DAPPER_HOST_ARCH} \
+    DOCKER_USER=${DOCKER_USER} \
+    DOCKER_PASS=${DOCKER_PASS}
+RUN apt-get update && \
+    apt-get install -y gcc ca-certificates git wget curl vim less file zip make && \
+    rm -f /bin/sh && ln -s /bin/bash /bin/sh
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+RUN wget -O - https://dl.google.com/go/go1.14.1.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+    go get github.com/rancher/trash && go get golang.org/x/lint/golint && go get -u github.com/jteeuwen/go-bindata/...
+COPY --from=0 /usr/local/bin/docker /usr/bin/docker
+RUN mkdir -p /.docker/cli-plugins
+COPY --from=0 /.docker/cli-plugins/docker-buildx /.docker/cli-plugins/docker-buildx
+ENV DOCKER_CLI_EXPERIMENTAL=enabled \
+    DOCKER_CONFIG=/.docker
+RUN docker buildx install
+ENV DAPPER_SOURCE /go/src/k8s.io/ingress-nginx/
+ENV DAPPER_OUTPUT ./bin ./dist
+ENV DAPPER_DOCKER_SOCKET true
+ENV DAPPER_ENV CROSS TAG
+ENV DAPPER_RUN_ARGS="--net host"
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+ENV GIT_IN_DAPPER true
+RUN mkdir -p /etc/nginx/geoip
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["./scripts/entry"]
+CMD ["ci"]

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,6 @@
 FROM docker:19.03.9
 ARG DAPPER_HOST_ARCH
+ARG STEP=ci
 ENV ARCH=${DAPPER_HOST_ARCH}
 RUN mkdir -p /.docker/cli-plugins
 RUN apk update && apk upgrade && apk add bash && ln -sf /bin/bash /bin/sh # use bash for subsequent variable expansion
@@ -41,4 +42,4 @@ ENV GIT_IN_DAPPER true
 RUN mkdir -p /etc/nginx/geoip
 WORKDIR ${DAPPER_SOURCE}
 ENTRYPOINT ["./scripts/entry"]
-CMD ["ci"]
+CMD [${STEP}]

--- a/Makefile
+++ b/Makefile
@@ -214,4 +214,4 @@ release: ensure-buildx clean
 		--build-arg VERSION="$(TAG)" \
 		--build-arg COMMIT_SHA="$(COMMIT_SHA)" \
 		--build-arg BUILD_ID="$(BUILD_ID)" \
-		-t $(REGISTRY)/controller:$(TAG) rootfs
+		-t $(REGISTRY)/nginx-ingress-controller:$(TAG) rootfs

--- a/Makefile_rancher
+++ b/Makefile_rancher
@@ -1,0 +1,23 @@
+TARGETS := $(shell ls scripts)
+
+.dapper:
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
+
+$(TARGETS): .dapper
+	./.dapper $@
+
+trash: .dapper
+	./.dapper -m bind trash
+
+trash-keep: .dapper
+	./.dapper -m bind trash -k
+
+deps: trash
+
+.DEFAULT_GOAL := ci
+
+.PHONY: $(TARGETS)

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/imdario/mergo v0.3.10
 	github.com/json-iterator/go v1.1.10
 	github.com/kylelemons/godebug v1.1.0
-	github.com/mitchellh/copystructure v1.0.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/mapstructure v1.3.2
@@ -29,8 +28,8 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tallclair/mdtoc v1.0.0
 	github.com/zakjan/cert-chain-resolver v0.0.0-20200729110141-6b99e360f97a
-	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	google.golang.org/grpc v1.27.1
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/pool.v3 v3.1.1

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
-github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
-github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
@@ -387,8 +385,6 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYGN7GeoRg=
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
-github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mmarkdown/mmark v2.0.40+incompatible h1:vMeUeDzBK3H+/mU0oMVfMuhSXJlIA+DE/DMPQNAj5C4=
 github.com/mmarkdown/mmark v2.0.40+incompatible/go.mod h1:Uvmoz7tvsWpr7bMVxIpqZPyN3FbOtzDmnsJDFp7ltJs=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
@@ -628,8 +624,9 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e h1:gsTQYXdTw2Gq7RBsWvlQ91b+aEQ6bXFUngBGuR8sPpI=
+golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -692,8 +689,9 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -752,8 +750,12 @@ golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -46,7 +46,9 @@ fi
 # We only need to do this setup on linux hosts
 if [ "$(uname)" == 'Linux' ]; then
   # NOTE: this is pinned to a digest for a reason!
-  docker run --rm --privileged multiarch/qemu-user-static@sha256:28ebe2e48220ae8fd5d04bb2c847293b24d7fbfad84f0b970246e0a4efd48ad6 --reset -p yes
+  # https://github.com/docker/buildx/issues/542#issuecomment-778835576
+  docker run --rm --privileged tonistiigi/binfmt --uninstall qemu-aarch64 && docker run --rm --privileged tonistiigi/binfmt --install arm64 
+  docker run --rm --privileged tonistiigi/binfmt
 fi
 
 # Ensure we use a builder that can leverage it (the default on linux will not)

--- a/internal/ingress/annotations/globalratelimit/main_test.go
+++ b/internal/ingress/annotations/globalratelimit/main_test.go
@@ -152,7 +152,7 @@ func TestGlobalRateLimiting(t *testing.T) {
 			},
 			&Config{},
 			ing_errors.LocationDenied{
-				Reason: errors.Wrap(fmt.Errorf(`time: unknown unit "mb" in duration "2mb"`),
+				Reason: errors.Wrap(fmt.Errorf("time: unknown unit mb in duration 2mb"),
 					"failed to parse 'global-rate-limit-window' value"),
 			},
 		},

--- a/internal/k8s/main.go
+++ b/internal/k8s/main.go
@@ -32,6 +32,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const (
+	internalAddressAnnotation = "rke.cattle.io/internal-ip"
+	externalAddressAnnotation = "rke.cattle.io/external-ip"
+)
+
 // ParseNameNS parses a string searching a namespace and name
 func ParseNameNS(input string) (string, string, error) {
 	nsName := strings.Split(input, "/")
@@ -62,6 +67,15 @@ func GetNodeIPOrName(kubeClient clientset.Interface, name string, useInternalIP 
 
 	if useInternalIP {
 		return defaultOrInternalIP
+	}
+
+	if node.Annotations != nil {
+		if annotatedIP := node.Annotations[externalAddressAnnotation]; annotatedIP != "" {
+			return annotatedIP
+		}
+		if annotatedIP := node.Annotations[internalAddressAnnotation]; annotatedIP != "" {
+			return annotatedIP
+		}
 	}
 
 	for _, address := range node.Status.Addresses {

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -34,7 +34,6 @@ LABEL build_id="${BUILD_ID}"
 WORKDIR  /etc/nginx
 
 RUN apk update \
-  && apk add apk-tools \
   && apk upgrade \
   && apk add --no-cache \
     diffutils \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -34,6 +34,7 @@ LABEL build_id="${BUILD_ID}"
 WORKDIR  /etc/nginx
 
 RUN apk update \
+  && apk add apk-tools \
   && apk upgrade \
   && apk add --no-cache \
     diffutils \

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+PKG="k8s.io/ingress-nginx"
+
+rm -rf bin/*
+mkdir -p bin
+
+declare -a arches=("arm64" "amd64")
+for arch in "${arches[@]}"
+do
+   ARCH=$arch DOCKER_IN_DOCKER_ENABLED=true USER=0 make build
+done

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+./validate
+./build
+./test
+./package

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,4 +6,4 @@ cd $(dirname $0)
 ./validate
 ./build
 ./test
-# ./package
+./package

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,4 +6,4 @@ cd $(dirname $0)
 ./validate
 ./build
 ./test
-./package
+# ./package

--- a/scripts/entry
+++ b/scripts/entry
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+mkdir -p bin dist
+if [ -e ./scripts/$1 ]; then
+    ./scripts/"$@"
+else
+    exec "$@"
+fi
+
+chown -R $DAPPER_UID:$DAPPER_GID .

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+REPO=${REPO:-rancher}
+
+source $(dirname $0)/version
+cd $(dirname $0)/..
+
+# manifest push happens as part of make release, so login is required inside the dapper container
+echo "$DOCKER_PASS" | docker login -u $DOCKER_USER --password-stdin
+
+REGISTRY=${REPO} PLATFORMS="arm64 amd64" TAG=${TAG} DOCKER_IN_DOCKER_ENABLED=true USER=0 make release

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec $(dirname $0)/ci

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running tests
+
+FIND_COMMAND="find"
+if [ "$(go env GOHOSTOS)" = "darwin" ]; then
+  FIND_COMMAND="find ."
+fi
+
+PACKAGES="$($FIND_COMMAND -name '*.go' | xargs -I{} dirname {} | sort -u | grep -Ev '(^\.$|.git|.trash-cache|vendor|bin|docs|test|controller/store|images|examples|hack)')"
+
+go test -v -p 1 -tags "cgo" -cover ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo Running validation
+
+PACKAGES="$(go list ./... | grep -v /vendor/)"
+
+echo Running: go vet
+go vet -mod=readonly ${PACKAGES}
+
+echo Running: go fmt
+test -z "$(go fmt -mod=readonly ${PACKAGES} | tee /dev/stderr)"

--- a/scripts/version
+++ b/scripts/version
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ "$GIT_IN_DAPPER" = true ]; then
+    git config --global user.email "rancher-ci@rancher.com"
+    git config --global user.name "rancher-ci"
+fi
+
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+    DIRTY="-dirty"
+fi
+
+# fetch tag information
+git fetch
+
+GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse --short HEAD)}
+GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
+REPO_INFO=$(git config --get remote.origin.url)
+
+if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
+    VERSION=$GIT_TAG
+else
+    VERSION="${GIT_COMMIT}${DIRTY}"
+fi
+
+if [ -z "$ARCH" ]; then
+    ARCH=amd64
+fi
+
+TAG=${TAG:-$VERSION}
+
+PKG="k8s.io/ingress-nginx"


### PR DESCRIPTION
- Create a new branch`nginx-0.48.x-fix` off of upstream's branch `controller-v0.48.1`
- Cherry-pick commits from `nginx-0.47.x-fix`

Notice the upstream branch `controller-v0.48.1` doesn't have a `0` patch number like all others. This is correct as it is what's upstream. My guess is there might have been an issue during their release because there is no `controller-v0.48.0` tag upstream.