### PR TITLE
Add s390x support [WIP]

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -86,3 +86,86 @@ volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
+
+---
+kind: pipeline
+name: ci-s390x
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  arch: s390x
+
+steps:
+- name: ci
+  image: rancher/dapper:v0.5.7
+  failure: ignore
+  commands:
+  - dapper -f Dockerfile-s390x.dapper ci 
+  environment:
+    DOCKER_PASS:
+      from_secret: docker_password
+    DOCKER_USER:
+      from_secret: docker_username
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - tag
+  instance:
+    - drone-publish.rancher.io
+
+- name: validate
+  image: rancher/dapper:v0.5.7
+  failure: ignore
+  commands:
+  - dapper -f Dockerfile-s390x.dapper validate
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - push
+    - pull_request
+    instance:
+    - drone-pr.rancher.io
+
+
+- name: build
+  image: rancher/dapper:v0.5.7
+  failure: ignore
+  commands:
+  - dapper -f Dockerfile-s390x.dapper build
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - push
+    - pull_request
+    instance:
+    - drone-pr.rancher.io
+
+
+- name: test
+  image: rancher/dapper:v0.5.7
+  failure: ignore
+  commands:
+  - dapper -f Dockerfile-s390x.dapper test
+  volumes:
+  - name: docker
+    path: /var/run/docker.sock
+  when:
+    event:
+    - push
+    - pull_request
+    instance:
+    - drone-pr.rancher.io
+
+volumes:
+- name: docker
+  host:
+    path: /var/run/docker.sock

--- a/Dockerfile-s390x.dapper
+++ b/Dockerfile-s390x.dapper
@@ -1,0 +1,45 @@
+FROM docker:18.06.3
+ARG DAPPER_HOST_ARCH
+ARG STEP=ci
+ENV ARCH=${DAPPER_HOST_ARCH}
+RUN mkdir -p /.docker/cli-plugins
+RUN apk update && apk upgrade && apk add bash && ln -sf /bin/bash /bin/sh # use bash for subsequent variable expansion
+ENV DOCKER_BUILDX_URL_s390x=https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-s390x
+RUN wget -O - ${DOCKER_BUILDX_URL_s390x} > /.docker/cli-plugins/docker-buildx && chmod +x /.docker/cli-plugins/docker-buildx
+
+FROM rancher/hardened-build-base:v1.16.9b7
+ARG DAPPER_HOST_ARCH
+ARG DOCKER_USER
+ARG DOCKER_PASS
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} \
+    ARCH=${DAPPER_HOST_ARCH} \
+    DOCKER_USER=${DOCKER_USER} \
+    DOCKER_PASS=${DOCKER_PASS}
+RUN apk add openssl
+ENV GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+COPY --from=0 /usr/local/bin/docker /usr/bin/docker
+RUN mkdir -p /.docker/cli-plugins
+COPY --from=0 /.docker/cli-plugins/docker-buildx /.docker/cli-plugins/docker-buildx
+ENV DOCKER_CLI_EXPERIMENTAL=enabled \
+    DOCKER_CONFIG=/.docker
+RUN docker buildx install
+ENV DAPPER_SOURCE /go/src/k8s.io/ingress-nginx/
+ENV DAPPER_OUTPUT ./bin ./dist
+ENV DAPPER_DOCKER_SOCKET true
+ENV DAPPER_ENV CROSS TAG REGISTRY PLATFORMS
+ENV DAPPER_RUN_ARGS="--net host"
+ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
+ENV HOME ${DAPPER_SOURCE}
+
+ENV GIT_IN_DAPPER=true
+ENV DOCKER_IN_DOCKER_ENABLED=true
+ENV USER=0
+ENV VERBOSE=1
+# build only works on amd64 for now
+ENV PLATFORMS=${ARCH}
+
+RUN mkdir -p /etc/nginx/geoip
+
+WORKDIR ${DAPPER_SOURCE}
+ENTRYPOINT ["./scripts/entry"]
+CMD [${STEP}]

--- a/build/build.sh
+++ b/build/build.sh
@@ -56,5 +56,7 @@ go-build-static.sh -trimpath -o "rootfs/bin/${ARCH}/dbg" "${PKG}/cmd/dbg"
 go-build-static.sh -trimpath -o "rootfs/bin/${ARCH}/wait-shutdown" "${PKG}/cmd/waitshutdown"
 
 go-assert-static.sh rootfs/bin/${ARCH}/*
+if [ "${ARCH}" != "s390x" ]; then \
 go-assert-boring.sh rootfs/bin/${ARCH}/*
+fi
 strip rootfs/bin/${ARCH}/*


### PR DESCRIPTION
- Add s390x drone pipeline
- Skipped e2e tests for s390x since kind doesn't support s390x. 
- Kind s390x is merged recently - https://github.com/kubernetes-sigs/kind/pull/2465. Will add e2e tests for s390x as soon as kind s390x binary is available. 

