### PR TITLE
[nginx-1.2.x] use rancher's repository image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,15 +239,4 @@ release: ensure-buildx clean
 		--build-arg VERSION="$(TAG)" \
 		--build-arg COMMIT_SHA="$(COMMIT_SHA)" \
 		--build-arg BUILD_ID="$(BUILD_ID)" \
-		-t $(REGISTRY)/controller:$(TAG) rootfs
-	
-	@docker buildx build \
-		--no-cache \
-		--push \
-		--progress plain \
-		--platform $(subst $(SPACE),$(COMMA),$(PLATFORMS)) \
-		--build-arg BASE_IMAGE="$(BASE_IMAGE)" \
-		--build-arg VERSION="$(TAG)" \
-		--build-arg COMMIT_SHA="$(COMMIT_SHA)" \
-		--build-arg BUILD_ID="$(BUILD_ID)" \
-		-t $(REGISTRY)/controller-chroot:$(TAG) rootfs -f rootfs/Dockerfile.chroot
+		-t $(REGISTRY)/nginx-ingress-controller:$(TAG) rootfs


### PR DESCRIPTION
Removing `controller-chroot` for now, we'll need to add support for it later on and allow users to set it to true. This is a new change with nginx v1.2.0. 