### PR TITLE
Use BCI base image

### DIFF
--- a/images/nginx/rootfs/Dockerfile.amd64
+++ b/images/nginx/rootfs/Dockerfile.amd64
@@ -54,6 +54,7 @@ RUN zypper addrepo \
     -p 105 http://download.opensuse.org/tumbleweed/repo/oss/ download.opensuse.org-oss && \
     zypper --gpg-auto-import-keys refresh
 RUN zypper install -y \
+        libcap-progs \
         libmaxminddb0 \
         liblmdb-0_9_17 \
         crypto-policies-scripts \

--- a/images/nginx/rootfs/Dockerfile.amd64
+++ b/images/nginx/rootfs/Dockerfile.amd64
@@ -37,8 +37,8 @@ RUN apk update \
   && apk upgrade \
   && apk add -U --no-cache dumb-init
 
-# With UBI as base image
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+# With BCI as base image
+FROM registry.suse.com/bci/bci-base:latest
 
 ENV PATH=$PATH:/usr/local/luajit/bin:/usr/local/nginx/sbin:/usr/local/nginx/bin
 
@@ -50,21 +50,19 @@ COPY --from=builder /opt /opt
 COPY --from=builder /etc/nginx /etc/nginx
 COPY --from=extras /usr/bin/dumb-init /usr/bin/dumb-init
 
-RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-RUN microdnf -y update && rm -rf /var/cache/yum
-RUN microdnf -y install lmdb-libs || rpm -iv http://vault.centos.org/centos/8/BaseOS/x86_64/os/Packages/lmdb-libs-0.9.24-1.el8.x86_64.rpm
-RUN microdnf -y install \
-      util-linux \
-      findutils \
-      which \
-      yajl \
-      GeoIP \
-      libmaxminddb \
-      wget
-
-RUN microdnf -y install crypto-policies-scripts
-
-RUN rm -rf /var/cache/yum
+RUN zypper addrepo \
+    -p 105 http://download.opensuse.org/tumbleweed/repo/oss/ download.opensuse.org-oss && \
+    zypper --gpg-auto-import-keys refresh
+RUN zypper install -y \
+        libmaxminddb0 \
+        liblmdb-0_9_17 \
+        crypto-policies-scripts \
+        wget \
+        which \
+        libyajl2 \
+        make \
+        tar \
+        gzip
 
 RUN ldDirs=" \
       /usr/local/lib \
@@ -77,7 +75,7 @@ RUN /sbin/ldconfig
 
 RUN ln -s /usr/local/nginx/sbin/nginx /sbin/nginx
 RUN groupadd -rg 101 www-data
-RUN adduser -u 101 -M -d /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
+RUN useradd -u 101 -M -d /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
 
 RUN writeDirs=" \
       /var/log/nginx \
@@ -92,8 +90,6 @@ RUN writeDirs=" \
     mkdir -p ${dir}; \
     chown -R www-data.www-data ${dir}; \
   done
-
-RUN microdnf clean all
 
 EXPOSE 80 443
 

--- a/images/nginx/rootfs/Dockerfile.amd64
+++ b/images/nginx/rootfs/Dockerfile.amd64
@@ -57,6 +57,7 @@ RUN zypper install -y \
         libcap-progs \
         libmaxminddb0 \
         liblmdb-0_9_17 \
+        libGeoIP1 \
         crypto-policies-scripts \
         wget \
         which \

--- a/images/nginx/rootfs/Dockerfile.amd64
+++ b/images/nginx/rootfs/Dockerfile.amd64
@@ -30,13 +30,6 @@ COPY build.sh /
 
 RUN /build.sh
 
-# Pull static components from alpine
-FROM alpine:3.13 as extras
-
-RUN apk update \
-  && apk upgrade \
-  && apk add -U --no-cache dumb-init
-
 # With BCI as base image
 FROM registry.suse.com/bci/bci-base:latest
 
@@ -48,7 +41,6 @@ ENV LUA_CPATH="/usr/local/lib/lua/?/?.so;/usr/local/lib/lua/?.so;;"
 COPY --from=builder /usr/local /usr/local
 COPY --from=builder /opt /opt
 COPY --from=builder /etc/nginx /etc/nginx
-COPY --from=extras /usr/bin/dumb-init /usr/bin/dumb-init
 
 RUN zypper addrepo \
     -p 105 http://download.opensuse.org/tumbleweed/repo/oss/ download.opensuse.org-oss && \
@@ -61,10 +53,12 @@ RUN zypper install -y \
         crypto-policies-scripts \
         wget \
         which \
+        git \
         libyajl2 \
         make \
         tar \
-        gzip
+        gzip \
+        catatonit
 
 RUN ldDirs=" \
       /usr/local/lib \

--- a/images/nginx/rootfs/Dockerfile.s390x
+++ b/images/nginx/rootfs/Dockerfile.s390x
@@ -54,7 +54,8 @@ RUN dnf -y install \
       libmaxminddb0 \
       lmdb \
       wget \
-      libcap-progs
+      libcap-progs \
+      catatonit
 
 RUN dnf -y install 'dnf-command(config-manager)'
 RUN dnf config-manager --add-repo https://download.opensuse.org/repositories/security:tls/openSUSE_Leap_15.3/security:tls.repo

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -61,8 +61,8 @@ RUN  setcap    cap_net_bind_service=+ep /nginx-ingress-controller \
   && setcap -v cap_net_bind_service=+ep /nginx-ingress-controller \
   && setcap    cap_net_bind_service=+ep /usr/local/nginx/sbin/nginx \
   && setcap -v cap_net_bind_service=+ep /usr/local/nginx/sbin/nginx \
-  && setcap    cap_net_bind_service=+ep /usr/bin/dumb-init \
-  && setcap -v cap_net_bind_service=+ep /usr/bin/dumb-init \
+  && setcap    cap_net_bind_service=+ep /usr/bin/catatonit \
+  && setcap -v cap_net_bind_service=+ep /usr/bin/catatonit \
   && ln -sf /usr/local/nginx/sbin/nginx /usr/bin/nginx
   
 USER www-data
@@ -71,6 +71,6 @@ USER www-data
 RUN  ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
 
 CMD ["/nginx-ingress-controller"]

--- a/rootfs/Dockerfile.chroot
+++ b/rootfs/Dockerfile.chroot
@@ -49,12 +49,7 @@ RUN if [ "$TARGETARCH" = "s390x" ] ; then dnf install -y \
      ca-certificates \
      diffutils \
      timezone \
-     util-linux ; else microdnf install bash \
-     curl \
-     openssl \
-     ca-certificates \
-     tzdata \
-     diffutils; fi
+     util-linux ; fi
 
 COPY --chown=www-data:www-data etc /chroot/etc
 

--- a/rootfs/Dockerfile.chroot
+++ b/rootfs/Dockerfile.chroot
@@ -77,8 +77,8 @@ RUN setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller 
   && setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare \
   && setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx \
   && setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx \
-  && setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init \
-  && setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init 
+  && setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/catatonit \
+  && setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/catatonit 
 
 RUN  ln -sf /chroot/etc/nginx /etc/nginx \
   && ln -sf /chroot/tmp/nginx /tmp/nginx \
@@ -100,7 +100,7 @@ USER www-data
 
 EXPOSE 80 443
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
 
 CMD ["/nginx-ingress-controller"]
  


### PR DESCRIPTION
This PR replaces UBI7 with BCI in the final base image. Part of a larger effort to remove uni images from rke2: https://github.com/rancher/rke2/issues/3260.