### PR TITLE
Fix tag CI failure

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -10,7 +10,7 @@ PKG="k8s.io/ingress-nginx"
 rm -rf bin/*
 mkdir -p bin
 
-declare -a arches=("arm64" "amd64")
+declare -a arches=("arm64" "amd64" "arm" "s390x")
 for arch in "${arches[@]}"
 do
    ARCH=$arch DOCKER_IN_DOCKER_ENABLED=true USER=0 make build


### PR DESCRIPTION
This PR adds `arm` and `s390x` in the `arches` in `scripts/build`.

Only `amd64` and `arm64` was in arches because of this the CI wasn't able to find the following files with not found error. `/bin/arm/nginx-ingress-controller`, `/bin/arm/wait-shutdown` and `/bin/arm/dbg`.
More at: https://drone-publish.rancher.io/rancher/ingress-nginx/215/1/2

This should fix the CI failures for tag.