### PR TITLE
[workflow] Update automation file to avoid conflicts and failure

### DIFF
--- a/.github/workflows/upstream-release-sync.yml
+++ b/.github/workflows/upstream-release-sync.yml
@@ -48,6 +48,7 @@ jobs:
   build-and-validate:
     needs: create-branches
     runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    if: ${{ needs.create-branches.outputs.new-release-branches != '[]' }} # Skip if no new branches
     container:
       image: rancher/dapper:v0.6.0
     permissions:

--- a/scripts/create-release-branch.sh
+++ b/scripts/create-release-branch.sh
@@ -37,6 +37,11 @@ for tag in $NEW_TAGS; do
     fi
     echo "[INFO] Checkout to a local branch nginx-${tag}-fix from the upstream tag controller-v$tag."
 
+    # delete .github/workflows and commit
+    echo "[INFO] Deleting .github/workflows files."
+    rm -rf .github/workflows/*
+    git add .github/workflows
+    git commit -m "Delete .github/workflows files"
 
     # Extract major and minor version from the tag
     major_minor=$(echo "${tag}" | cut -d '.' -f 1,2)
@@ -62,11 +67,28 @@ for tag in $NEW_TAGS; do
     FAIL=0
     # Cherry-pick all commits before the user's commit
     for commit in $cherry_pick_commits; do
-        echo "[INFO] Cherry pick commit: $commit to branch: nginx-${tag}-fix"
-        if ! git cherry-pick "$commit" > /dev/null; then
-            echo "[WARN] Failed during cherry-pick of commit $commit in branch nginx-${tag}-fix. Skipping the version ${tag}."
-            FAIL=1
-            break
+        if [[ $(git log --format=%B -n 1 $commit) == *"go generate"* ]]; then
+            echo "[INFO] This is a go generate commit, not cherry picking."
+            echo "[INFO] Performing 'go generate ./...'"
+            if ! go generate ./... > /dev/null; then
+                echo "[WARN] Failed during go generate in branch release-${tag}. Skipping the version ${tag}."
+                FAIL=1
+                break
+            fi
+            echo "[INFO] Commit go generate changes"
+            git add .
+            if ! $(git commit -m "${cherry_pick_label} go generate" > /dev/null); then
+                echo "[WARN] Failed in commiting go generate in branch release-${tag}. Skipping the version ${tag}."
+                FAIL=1
+                break
+            fi
+        else
+            echo "[INFO] Cherry pick commit: $commit to branch: nginx-${tag}-fix"
+            if ! git cherry-pick "$commit" > /dev/null; then
+                echo "[WARN] Failed during cherry-pick of commit $commit in branch nginx-${tag}-fix. Skipping the version ${tag}."
+                FAIL=1
+                break
+            fi
         fi
     done
 

--- a/scripts/create-release-branch.sh
+++ b/scripts/create-release-branch.sh
@@ -105,16 +105,15 @@ echo "==========================================================================
 # Print the new branches
 if [ ${#NEW_RELEASE_BRANCHES[@]} -eq 0 ]; then
     echo "[ERROR] No new release branches."
-    exit 1
+    exit 0
 else
     echo "[INFO] New release branches:"
     for branch in "${NEW_RELEASE_BRANCHES[@]}"; do
         echo "- $branch"
-    done
-fi
 
-# Convert NEW_RELEASE_BRANCHES array to JSON string
-echo "NEW_RELEASE_BRANCHES=$(printf '%s\n' "${NEW_RELEASE_BRANCHES[@]}" | awk '{printf "\"%s\",", $0}' | sed 's/,$/]/' | sed 's/^/[/' )" >> $GITHUB_OUTPUT
+    # Convert NEW_RELEASE_BRANCHES array to JSON string
+    echo "NEW_RELEASE_BRANCHES=$(printf '%s\n' "${NEW_RELEASE_BRANCHES[@]}" | awk '{printf "\"%s\",", $0}' | sed 's/,$/]/' | sed 's/^/[/' )" >> $GITHUB_OUTPUT
+fi
 
 # Clean up temporary files
 rm -f "$rancher_tags_file"


### PR DESCRIPTION
- Skip cherry-pick for go generate commits and automatically run go generate during release branch creation.
- Delete github workflow files manually to remove merge conflicts.
- Updated `create-release-branch.sh` to ensure graceful handling when no new tags are found.
- Added logic to skip the `build-and-validate` job in the workflow if no new branches are created.


