### PR TITLE
fix: use RKE2 patched nginx as base image to address Nginx Rift CVEs for RKE1 controller image

### DIFF
--- a/NGINX_BASE
+++ b/NGINX_BASE
@@ -1,1 +1,1 @@
-registry.k8s.io/ingress-nginx/nginx:v2.2.8@sha256:1c31dc6ffa7427b7a2128ce66e356f3b0ff743b90494272612b1742c9326b8b2
+rancher/nginx:v1.14.5-prime7

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -33,11 +33,8 @@ LABEL build_id="${BUILD_ID}"
 
 WORKDIR  /etc/nginx
 
-RUN apk update \
-  && apk upgrade \
-  && apk add --no-cache \
-    diffutils \
-  && rm -rf /var/cache/apk/*
+RUN zypper install -y diffutils \
+  && zypper clean --all
 
 COPY --chown=www-data:www-data etc /etc
 
@@ -68,14 +65,12 @@ RUN bash -xeu -c ' \
   && echo "/lib:/usr/lib:/usr/local/lib:/modules_mount/etc/nginx/modules/otel" > /etc/ld-musl-x86_64.path
   
 
-RUN apk add --no-cache libcap \
-  && setcap    cap_net_bind_service=+ep /nginx-ingress-controller \
+RUN  setcap    cap_net_bind_service=+ep /nginx-ingress-controller \
   && setcap -v cap_net_bind_service=+ep /nginx-ingress-controller \
   && setcap    cap_net_bind_service=+ep /usr/local/nginx/sbin/nginx \
   && setcap -v cap_net_bind_service=+ep /usr/local/nginx/sbin/nginx \
-  && setcap    cap_net_bind_service=+ep /usr/bin/dumb-init \
-  && setcap -v cap_net_bind_service=+ep /usr/bin/dumb-init \
-  && apk del libcap \
+  && setcap    cap_net_bind_service=+ep /usr/bin/catatonit \
+  && setcap -v cap_net_bind_service=+ep /usr/bin/catatonit \
   && ln -sf /usr/local/nginx/sbin/nginx /usr/bin/nginx
 
 USER www-data
@@ -84,5 +79,5 @@ USER www-data
 RUN  ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
 CMD ["/nginx-ingress-controller"]


### PR DESCRIPTION
This PR addresses the Nginx Rift CVEs for RKE1 Extended Life support by replacing the upstream nginx base image with the patched nginx image published as part of the RKE2 hardened build pipeline.

## Problem
RKE1 ingress-nginx controller references the upstream nginx image as its base: registry.k8s.io/ingress nginx/nginx:v2.2.8
Unlike RKE2, RKE1 does not maintain an internal nginx build pipeline and has always consumed the upstream nginx image without modification. As a result, CVE patches applied in RKE2 are not present in the RKE1 controller image.

## Changes

### NGINX_BASE
The base image has been updated to reference the RKE2 patched nginx image which contains all CVE fixes applied via the RKE2 hardened build pipeline:
- From: `registry.k8s.io/ingress-nginx/nginx:v2.2.8`
- To: `rancher/nginx:v1.14.5-prime7`

### rootfs/Dockerfile
The RKE2 nginx image is built on SUSE BCI (Base Container Image) rather than Alpine Linux. The following changes to the controller Dockerfile were required to ensure compatibility with the BCI base:

- Replace `apk` with `zypper` for diffutils installation as SUSE BCI does not include the apk package manager 
- Replace `dumb-init` with `catatonit` as PID 1 process as`dumb-init` is not present in BCI base, `catatonit` is already included 
- Remove `apk add/del libcap` steps , `setcap` is already available in BCI via `libcap-progs` 

## Testing

The following verification was performed on a locally built image deployed to an RKE1 cluster provisioned on EC2:

- [x] Image builds successfully using dapper CI
- [x] RKE1 cluster provisioned successfully and reached Active state
- [x] nginx-ingress-controller pod running successfully
- [x] nginx version 1.27.1 confirmed inside running pod
- [x] SUSE BCI 16.0 confirmed as base OS inside pod