### PR TITLE
Build kube-webhook-certgen as a package to embed Go module info

### DIFF
--- a/images/kube-webhook-certgen/rootfs/Dockerfile
+++ b/images/kube-webhook-certgen/rootfs/Dockerfile
@@ -22,7 +22,7 @@ ARG TARGETARCH
 
 WORKDIR /workspace
 COPY . .
-RUN go mod tidy && CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o kube-webhook-certgen main.go
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o kube-webhook-certgen .
 
 FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot
 ARG BUILDPLATFORM


### PR DESCRIPTION
## Problem

The `kube-webhook-certgen` image builds its binary with:

```dockerfile
RUN go mod tidy && CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o kube-webhook-certgen main.go
```

Building a **named file** (`main.go`) rather than the **package** (`.`) makes Go record the main package as `command-line-arguments` and **omit the module build-info line**. On the shipped binary, `go version -m` shows:

```
pathcommand-line-arguments
depgithub.com/jet/kube-webhook-certgen(devel)     ← only a dep, no `mod` line
```

There is no `mod` entry, so the binary carries no main-module metadata.

## Impact

That missing metadata breaks downstream supply-chain tooling:

- **Trivy / govulncheck** can't attribute the main module of the binary.
- The **`rancher/image-scanning` auto-VEX workflow** derives the product purl from `go version -m` (`check_go_modpath`, grep `^\tmod\t`). With no `mod` line it returns empty and the job `fatal`s, so false-positive CVEs in this image (e.g. the `golang.org/x/net/html` family, which is dead-code-eliminated here) can't be VEXed through the normal pipeline.

## Fix

Build the package instead of the named file:

```diff
- go build -a -o kube-webhook-certgen main.go
+ go build -a -o kube-webhook-certgen .
```

`main.go` is just `package main` importing `github.com/jet/kube-webhook-certgen/cmd`, so this produces an **identical binary** — but now Go records `mod github.com/jet/kube-webhook-certgen`, restoring module provenance and unblocking the scanning/VEX tooling.

## Testing

- No functional change to the binary (same package, same entrypoint).
- After this change `go version -m kube-webhook-certgen` will include a `mod github.com/jet/kube-webhook-certgen ...` line.